### PR TITLE
Invulnerability and Passthrough

### DIFF
--- a/Assets/Models/Animators/ArcherAnimator.controller
+++ b/Assets/Models/Animators/ArcherAnimator.controller
@@ -52,9 +52,9 @@ AnimatorStateMachine:
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_AnyStatePosition: {x: 70, y: 80, z: 0}
+  m_EntryPosition: {x: 70, y: 120, z: 0}
+  m_ExitPosition: {x: 70, y: 40, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 6795734872730669797}
 --- !u!1102 &-1659212653726093932
@@ -145,7 +145,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Idle
-  m_Speed: 1
+  m_Speed: 3
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []

--- a/Assets/Scripts/Environment/TargetDummy.cs
+++ b/Assets/Scripts/Environment/TargetDummy.cs
@@ -71,7 +71,7 @@ namespace nickmaltbie.Treachery.Environment
         public override void FixedUpdate()
         {
             base.FixedUpdate();
-            var damageable = GetComponent<Damageable>();
+            Damageable damageable = GetComponent<Damageable>();
             InvulnerableAttribute.UpdateDamageableState(CurrentState, damageable);
             DamagePassthroughAttribute.UpdateDamageableState(CurrentState, damageable);
         }

--- a/Assets/Scripts/Environment/TargetDummy.cs
+++ b/Assets/Scripts/Environment/TargetDummy.cs
@@ -58,6 +58,7 @@ namespace nickmaltbie.Treachery.Environment
 
         [Animation(RevivingAnimState, 1.0f, true)]
         [TransitionOnAnimationComplete(typeof(IdleState), 0.35f)]
+        [Invulnerable]
         public class RevivingState : State { }
 
         public void Awake()
@@ -65,6 +66,14 @@ namespace nickmaltbie.Treachery.Environment
             IDamageable damageable = GetComponent<IDamageable>();
             damageable.OnDamageEvent += OnDamage;
             gameObject.AddComponent<ReviveEventManager>();
+        }
+
+        public override void FixedUpdate()
+        {
+            base.FixedUpdate();
+            var damageable = GetComponent<Damageable>();
+            InvulnerableAttribute.UpdateDamageableState(CurrentState, damageable);
+            DamagePassthroughAttribute.UpdateDamageableState(CurrentState, damageable);
         }
 
         public void OnDamage(object source, OnDamagedEvent onDamagedEvent)

--- a/Assets/Scripts/Interactive/Arrow.cs
+++ b/Assets/Scripts/Interactive/Arrow.cs
@@ -16,7 +16,6 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using nickmaltbie.Treachery.Interactive.Health;
 using nickmaltbie.Treachery.Interactive.Hitbox;
@@ -145,7 +144,7 @@ namespace nickmaltbie.Treachery.Interactive
             }
             else
             {
-                var arrowDamageEvent = IHitbox.DamageEventFromHit(hit, hitbox, arrowDamage, normal, DamageType.Piercing);
+                DamageEvent arrowDamageEvent = IHitbox.DamageEventFromHit(hit, hitbox, arrowDamage, normal, DamageType.Piercing);
                 Fired = false;
                 hitbox.Source.ApplyDamage(arrowDamageEvent);
                 SpawnPincushionArrowOnDamageClientRpc(arrowDamageEvent);

--- a/Assets/Scripts/Interactive/Breakeable/BreakableObject.cs
+++ b/Assets/Scripts/Interactive/Breakeable/BreakableObject.cs
@@ -147,7 +147,7 @@ namespace nickmaltbie.Treachery.Interactive.Breakeable
             if (brokenState.Value == BreakableObjectState.Fixed)
             {
                 fixedSpawn ??= GameObject.Instantiate(fixedPrefab, transform.position, transform.rotation, transform);
-                foreach (var hitbox in GetComponentsInChildren<GenericHitbox>())
+                foreach (GenericHitbox hitbox in GetComponentsInChildren<GenericHitbox>())
                 {
                     hitbox.Disabled = false;
                 }
@@ -161,7 +161,7 @@ namespace nickmaltbie.Treachery.Interactive.Breakeable
             if (brokenState.Value == BreakableObjectState.Broken)
             {
                 brokenSpawn ??= GameObject.Instantiate(brokenPrefab, transform.position, transform.rotation, transform);
-                foreach (var hitbox in GetComponentsInChildren<GenericHitbox>())
+                foreach (GenericHitbox hitbox in GetComponentsInChildren<GenericHitbox>())
                 {
                     hitbox.Disabled = true;
                 }

--- a/Assets/Scripts/Interactive/Health/Damageable.cs
+++ b/Assets/Scripts/Interactive/Health/Damageable.cs
@@ -44,6 +44,8 @@ namespace nickmaltbie.Treachery.Interactive.Health
 
         public float MaxHealth => maxHealth.Value;
         public float CurrentHealth => currentHealth.Value;
+        public bool Invulnerable { get; set; } = false;
+        public bool Passthrough { get; set; } = false;
 
         private void AdjustHealth(float change)
         {
@@ -99,7 +101,7 @@ namespace nickmaltbie.Treachery.Interactive.Health
             float adjust = damageEvent.amount;
             if (damageEvent.type == EventType.Damage)
             {
-                if (!IsAlive())
+                if (!IsAlive() || Invulnerable)
                 {
                     return;
                 }

--- a/Assets/Scripts/Interactive/Health/IDamageable.cs
+++ b/Assets/Scripts/Interactive/Health/IDamageable.cs
@@ -29,7 +29,16 @@ namespace nickmaltbie.Treachery.Interactive.Health
         float GetRemainingHealth();
         float GetMaxHealth();
         float GetHealthPercentage();
+
+        /// <summary>
+        /// Is this damageable entity still alive.
+        /// </summary>
         bool IsAlive();
+
+        /// <summary>
+        /// Should attacks passthrough this damageable entity due to dodging.
+        /// </summary>
+        bool Passthrough { get; }
 
         event EventHandler<OnDamagedEvent> OnDamageEvent;
         event EventHandler OnResetHealth;

--- a/Assets/Scripts/Interactive/Hitbox/GenericHitbox.cs
+++ b/Assets/Scripts/Interactive/Hitbox/GenericHitbox.cs
@@ -34,9 +34,12 @@ namespace nickmaltbie.Treachery.Interactive.Hitbox
         public IDamageable Source => damageable;
 
         public bool disabledOverride = false;
-
         public string HitboxId { get; private set; }
-        public bool Disabled { get; set; }
+        public bool Disabled
+        {
+            get => disabledOverride || Source.Passthrough;
+            set => disabledOverride = value;
+        }
 
         public void Awake()
         {

--- a/Assets/Scripts/Interactive/Hitbox/IHitbox.cs
+++ b/Assets/Scripts/Interactive/Hitbox/IHitbox.cs
@@ -94,7 +94,10 @@ namespace nickmaltbie.Treachery.Interactive.Hitbox
                 IHitbox checkHitbox = hit.collider?.GetComponent<IHitbox>();
 
                 // Don't let the player hit him/her self.
-                if (checkHitbox != null && checkHitbox.Source == source)
+                // Also ignore disabled hitboxes or hitboxes with passthrough set.
+                bool ignoreHitbox = checkHitbox != null &&
+                    (checkHitbox.Source == source || checkHitbox.Disabled || (checkHitbox.Source?.Passthrough ?? false));
+                if (ignoreHitbox)
                 {
                     continue;
                 }
@@ -105,7 +108,7 @@ namespace nickmaltbie.Treachery.Interactive.Hitbox
                     didHit = true;
                     return null;
                 }
-                else if (!checkHitbox.Disabled)
+                else
                 {
                     // we had a valid hit, return this hitbox.
                     firstHit = hit;

--- a/Assets/Scripts/Player/DamageableAttribute.cs
+++ b/Assets/Scripts/Player/DamageableAttribute.cs
@@ -1,3 +1,20 @@
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 using System;
 using nickmaltbie.Treachery.Interactive.Health;

--- a/Assets/Scripts/Player/DamageableAttribute.cs
+++ b/Assets/Scripts/Player/DamageableAttribute.cs
@@ -1,0 +1,36 @@
+
+using System;
+using nickmaltbie.Treachery.Interactive.Health;
+
+namespace nickmaltbie.Treachery.Player
+{
+    public class DamagePassthroughAttribute : Attribute
+    {
+        public static void UpdateDamageableState(Type currentState, Damageable damageable)
+        {
+            if (Attribute.GetCustomAttribute(currentState, typeof(DamagePassthroughAttribute)) is DamagePassthroughAttribute)
+            {
+                damageable.Passthrough = true;
+            }
+            else
+            {
+                damageable.Passthrough = false;
+            }
+        }
+    }
+
+    public class InvulnerableAttribute : Attribute
+    {
+        public static void UpdateDamageableState(Type currentState, Damageable damageable)
+        {
+            if (Attribute.GetCustomAttribute(currentState, typeof(InvulnerableAttribute)) is InvulnerableAttribute)
+            {
+                damageable.Invulnerable = true;
+            }
+            else
+            {
+                damageable.Invulnerable = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Player/DamageableAttribute.cs.meta
+++ b/Assets/Scripts/Player/DamageableAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 899170017cee58944946690ad1f98a59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Survivor.cs
+++ b/Assets/Scripts/Player/Survivor.cs
@@ -382,7 +382,7 @@ namespace nickmaltbie.Treachery.Player
                 Velocity = Vector3.zero;
             }
 
-            var damageable = GetComponent<Damageable>();
+            Damageable damageable = GetComponent<Damageable>();
             InvulnerableAttribute.UpdateDamageableState(CurrentState, damageable);
             DamagePassthroughAttribute.UpdateDamageableState(CurrentState, damageable);
             base.FixedUpdate();

--- a/Assets/Scripts/Player/Survivor.cs
+++ b/Assets/Scripts/Player/Survivor.cs
@@ -255,6 +255,7 @@ namespace nickmaltbie.Treachery.Player
         [OnFixedUpdate(nameof(DodgeMovement))]
         [OnEnterState(nameof(OnStartDodge))]
         [LockMovementAnimation]
+        [DamagePassthrough]
         [BlockAllAction]
         public class DodgeState : State { }
 
@@ -278,11 +279,13 @@ namespace nickmaltbie.Treachery.Player
 
         [Animation(DeadAnimState, 0.35f, true)]
         [Transition(typeof(PlayerReviveEvent), typeof(RevivingState))]
+        [Invulnerable]
         [BlockAllAction]
         public class DeadState : State { }
 
         [Animation(RevivingAnimState, 1.0f, true)]
         [TransitionOnAnimationComplete(typeof(IdleState), 0.35f)]
+        [Invulnerable]
         [BlockAllAction]
         public class RevivingState : State { }
 
@@ -379,6 +382,9 @@ namespace nickmaltbie.Treachery.Player
                 Velocity = Vector3.zero;
             }
 
+            var damageable = GetComponent<Damageable>();
+            InvulnerableAttribute.UpdateDamageableState(CurrentState, damageable);
+            DamagePassthroughAttribute.UpdateDamageableState(CurrentState, damageable);
             base.FixedUpdate();
         }
 


### PR DESCRIPTION
# Description

Added ability for projectiles to pass through certain hitboxes if they are labeled as so by disabling them.
Also allowed for Damageable object to enter "Invulnerable" state where they will still block attacks but cannot be hit in the invulnerable state.

