### PR TITLE
Fixed small bug causing items to not spawn on starting server

### DIFF
--- a/Assets/Scripts/Equipment/GeneratedItemSpawner.cs
+++ b/Assets/Scripts/Equipment/GeneratedItemSpawner.cs
@@ -51,7 +51,6 @@ namespace nickmaltbie.Treachery.Equipment
         public void ResetState()
         {
             spawned = false;
-            NetworkManager.Singleton.OnServerStarted -= ResetState;
         }
 
         public GameObject PreviewPrefab()


### PR DESCRIPTION
# Description

Found a small bug that caused the `ItemSpawner` prefab to not spawn items properly when the server is restarted.

# How Has This Been Tested?

Tested changes locally by resetting server many times.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
