### PR TITLE
Blocking Via Stamina

### DIFF
--- a/Assets/Scripts/Environment/StaticArcher.cs
+++ b/Assets/Scripts/Environment/StaticArcher.cs
@@ -39,6 +39,7 @@ namespace nickmaltbie.Treachery.Environment
     public class StaticArcher : NetworkSMAnim
     {
         public float arrowFireSpeed = 50.0f;
+        public float arrowDamage = 20.0f;
 
         public class DrawArrowEvent : IEvent { }
 
@@ -91,6 +92,7 @@ namespace nickmaltbie.Treachery.Environment
                 Transform arrowTransform = aimHelper.ArrowTransform;
                 Arrow firedArrow = GameObject.Instantiate(aimHelper.arrowPrefab, arrowTransform.position, arrowTransform.rotation);
                 firedArrow.GetComponent<NetworkObject>().Spawn(true);
+                firedArrow.arrowDamage = arrowDamage;
 
                 Transform targetPosition = aimHelper.targetPosition;
                 Vector3 dir = targetPosition.position - firedArrow.transform.position;

--- a/Assets/Scripts/Interactive/Health/DamageEvent.cs
+++ b/Assets/Scripts/Interactive/Health/DamageEvent.cs
@@ -38,8 +38,6 @@ namespace nickmaltbie.Treachery.Interactive.Health
     public struct OnDamagedEvent
     {
         public DamageEvent damageEvent;
-        public float previousHealth;
-        public float currentHealth;
     }
 
     public struct DamageEvent

--- a/Assets/Scripts/Interactive/Health/Damageable.cs
+++ b/Assets/Scripts/Interactive/Health/Damageable.cs
@@ -67,9 +67,8 @@ namespace nickmaltbie.Treachery.Interactive.Health
             if (spendStamina && damage)
             {
                 float staminaCost = Mathf.Abs(change) * StaminaSplit;
-                change *= Mathf.Clamp(1 - StaminaSplit, 0, 1);
-
-                Stamina.SpendStamina(staminaCost);
+                float staminaLost = Mathf.Abs(Stamina.ExhaustStamina(staminaCost));
+                change = Mathf.Clamp(change + staminaLost, change, 0);
             }
 
             bool wasAlive = IsAlive();

--- a/Assets/Scripts/Interactive/Health/Damageable.cs
+++ b/Assets/Scripts/Interactive/Health/Damageable.cs
@@ -64,7 +64,6 @@ namespace nickmaltbie.Treachery.Interactive.Health
             bool damage = change < 0;
             bool spendStamina = Stamina != null && StaminaSplit >= 0;
 
-            UnityEngine.Debug.Log($"{gameObject.name} -- Stamina:{Stamina} != null && StaminaSplit:{StaminaSplit} >= 0");
             if (spendStamina && damage)
             {
                 float staminaCost = Mathf.Abs(change) * StaminaSplit;
@@ -143,6 +142,11 @@ namespace nickmaltbie.Treachery.Interactive.Health
         [ClientRpc]
         public void OnResetHealthClientRpc()
         {
+            if (IsOwner)
+            {
+                currentHealth.Value = maxHealth.Value;
+            }
+
             OnResetHealth?.Invoke(this, EventArgs.Empty);
         }
 
@@ -158,7 +162,7 @@ namespace nickmaltbie.Treachery.Interactive.Health
 
         public void ResetToMaxHealth()
         {
-            currentHealth.Value = maxHealth.Value;
+            OnResetHealthClientRpc();
         }
 
         public string AddHitbox(IHitbox hitbox, string name = "")

--- a/Assets/Scripts/Interactive/Particles/BleedOnHit.cs
+++ b/Assets/Scripts/Interactive/Particles/BleedOnHit.cs
@@ -40,6 +40,12 @@ namespace nickmaltbie.Treachery.Interactive.Particles
             particles.transform.SetParent(sourceTransform);
             particles.transform.position = sourceTransform.localToWorldMatrix * onDamagedEvent.damageEvent.relativeHitPos;
             particles.transform.rotation = Quaternion.FromToRotation(Vector3.forward, onDamagedEvent.damageEvent.hitNormal);
+            particles.transform.localScale = Vector3.one;
+            if (sourceTransform != null)
+            {
+                particles.transform.localScale = sourceTransform.lossyScale;
+            }
+
             particles.Stop();
             particles.Play();
         }

--- a/Assets/Scripts/Interactive/Stamina/IStaminaMeter.cs
+++ b/Assets/Scripts/Interactive/Stamina/IStaminaMeter.cs
@@ -48,7 +48,8 @@ namespace nickmaltbie.Treachery.Interactive.Stamina
         /// Exhaust some stamina from the actor.
         /// </summary>
         /// <param name="amount">Amount of stamina to exhaust.</param>
-        void ExhaustStamina(float amount);
+        /// <returns>The amount of stamina actually lost.</returns>
+        float ExhaustStamina(float amount);
 
         /// <summary>
         /// Spend some stamina if the player has enough.

--- a/Assets/Scripts/Interactive/Stamina/StaminaMeter.cs
+++ b/Assets/Scripts/Interactive/Stamina/StaminaMeter.cs
@@ -86,9 +86,11 @@ namespace nickmaltbie.Treachery.Interactive.Stamina
         /// Adjust the current remaining stamina by some amount.
         /// </summary>
         /// <param name="amount">Increase or decrease stamina by some amount.</param>
-        private void AdjustStamina(float amount)
+        private float AdjustStamina(float amount)
         {
+            float previous = RemainingStamina;
             RemainingStamina = Mathf.Clamp(RemainingStamina + amount, 0, MaximumStamina);
+            return RemainingStamina - previous;
         }
 
         /// <inheritdoc/>
@@ -98,13 +100,16 @@ namespace nickmaltbie.Treachery.Interactive.Stamina
         }
 
         /// <inheritdoc/>
-        public void ExhaustStamina(float amount)
+        public float ExhaustStamina(float amount)
         {
             if (amount > 0)
             {
-                AdjustStamina(-amount);
+                float change = AdjustStamina(-amount);
                 lastStaminaSpendTime = Time.time;
+                return change;
             }
+
+            return 0;
         }
 
         /// <inheritdoc/>

--- a/Assets/Scripts/Player/Survivor.cs
+++ b/Assets/Scripts/Player/Survivor.cs
@@ -465,6 +465,12 @@ namespace nickmaltbie.Treachery.Player
         {
             bool denyMovement = PlayerInputUtils.playerMovementState == PlayerInputState.Deny;
             Vector2 moveVector = denyMovement ? Vector2.zero : MoveAction?.ReadValue<Vector2>() ?? Vector2.zero;
+
+            if (!GetComponent<Damageable>().IsAlive())
+            {
+                moveVector = Vector2.zero;
+            }
+
             InputMovement = new Vector3(moveVector.x, 0, moveVector.y);
 
             bool locked = LockMovementAnimationAttribute.IsMovementAnimationLocked(CurrentState);

--- a/Assets/Scripts/Player/Survivor.cs
+++ b/Assets/Scripts/Player/Survivor.cs
@@ -234,7 +234,7 @@ namespace nickmaltbie.Treachery.Player
         [Transition(typeof(StartMoveInput), typeof(BlockMoveState))]
         [Transition(typeof(BlockStop), typeof(IdleState))]
         [BlockEnabled]
-        [DamageMultiplier(multiplier = 0.5f)]
+        [DamageMultiplier(damageMultiplier = 0.9f, staminaSplit = 0.5f)]
         public class BlockIdleState : State { }
 
         [Animation(WalkingAnimState, 0.1f, true)]
@@ -242,7 +242,7 @@ namespace nickmaltbie.Treachery.Player
         [Transition(typeof(BlockStop), typeof(WalkingState))]
         [BlockEnabled]
         [MovementSettings(SpeedConfig = nameof(blockSpeed))]
-        [DamageMultiplier(multiplier = 0.5f)]
+        [DamageMultiplier(damageMultiplier = 0.5f, staminaSplit = 0.5f)]
         public class BlockMoveState : State { }
 
         [Animation(SlidingAnimState, 0.35f, true)]


### PR DESCRIPTION
# Description

Added ability for player block to spend stamina while blocking.
* Needed to switch player health to be controlled by owner as it impacts actions as well now.
* Added ability for player block to cost stamina as following design in #27 
* On damage events needed to be reworked a bit in how they are sent between client and server.
* Adjusted blocking to have a 10% damage reduction and 50% stamina/health split.

Closes #27 

# How Has This Been Tested?

Tested changes locally as well as with multiple clients to ensure player events work as expected.

Tested that player stamina drops when blocking and taking damage
* Ensured this works on client as well as server
* Adjusted damage of archer from 10 to 20 to demo this ability

Verified that when damage exceeds current stamina level, health with decrease more.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
