### PR TITLE
Player Loadout Refactor

### DIFF
--- a/Assets/Input/InputSystem.inputactions
+++ b/Assets/Input/InputSystem.inputactions
@@ -69,15 +69,6 @@
                     "initialStateCheck": false
                 },
                 {
-                    "name": "Zoom",
-                    "type": "PassThrough",
-                    "id": "3320648e-a821-491f-bb3b-9cde6b475a53",
-                    "expectedControlType": "Vector2",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "Attack",
                     "type": "Button",
                     "id": "ce8e3a26-9f0e-4137-935f-ec93dce1581f",
@@ -108,15 +99,6 @@
                     "name": "NextLoadout",
                     "type": "Button",
                     "id": "19006367-e096-48ac-9adf-11312876dd01",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "Press",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "PreviousLoadout",
-                    "type": "Button",
-                    "id": "6f73c2d2-9e01-4098-a4df-eedef2a0f75e",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press",
@@ -376,22 +358,11 @@
                 {
                     "name": "",
                     "id": "00b18b61-6601-4180-96cb-64ee7d5855c4",
-                    "path": "<Mouse>/forwardButton",
+                    "path": "<Keyboard>/tab",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
                     "action": "NextLoadout",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "0a12cbe3-c053-42ef-804e-900a7831f7b3",
-                    "path": "<Mouse>/backButton",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "PreviousLoadout",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -438,61 +409,6 @@
                     "action": "Secondary",
                     "isComposite": false,
                     "isPartOfComposite": false
-                },
-                {
-                    "name": "Manual Zoom",
-                    "id": "601304a6-8599-4d68-b899-51be45aa62d2",
-                    "path": "2DVector",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": true,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "up",
-                    "id": "75bed328-50c1-47b5-b122-1aa453408555",
-                    "path": "<Keyboard>/z",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "down",
-                    "id": "04f30341-5e2c-4b44-9e28-b15293944c34",
-                    "path": "<Keyboard>/x",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "left",
-                    "id": "f30cf99c-175d-4183-a10f-12c5250e5c54",
-                    "path": "",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
-                },
-                {
-                    "name": "right",
-                    "id": "b7a147f1-3ad5-48bb-a1c4-462e4990002c",
-                    "path": "",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Zoom",
-                    "isComposite": false,
-                    "isPartOfComposite": true
                 },
                 {
                     "name": "",

--- a/Assets/Prefab/NetworkPlayer.prefab
+++ b/Assets/Prefab/NetworkPlayer.prefab
@@ -456,9 +456,9 @@ MonoBehaviour:
     rotationRate: 180
     cameraTransform: {fileID: 1928389238472999755}
     baseCameraOffset: {x: 0, y: 0, z: 0}
-    minCameraDistance: 0
-    maxCameraDistance: 4
-    currentDistance: 0
+    minCameraDistance: 2
+    maxCameraDistance: 3
+    currentDistance: 2
     zoomSpeed: 1
     cameraRaycastMask:
       serializedVersion: 2
@@ -566,10 +566,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 317b11fbc2aa79a45a40e9c6b855557e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MaxLoadouts: 3
+  MaxLoadouts: 2
   manager: {fileID: 0}
   throwVelocity: 6.5
   dropItemInputAction: {fileID: -8197223153440005221, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}
   incrementLoadoutSelection: {fileID: -1289574976295722738, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}
-  decrementLoadoutSelection: {fileID: 4700168074898257696, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}
+  decrementLoadoutSelection: {fileID: 0}
   loadoutScroll: {fileID: -5585577661466553000, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}

--- a/Assets/Prefab/NetworkPlayer.prefab
+++ b/Assets/Prefab/NetworkPlayer.prefab
@@ -569,6 +569,7 @@ MonoBehaviour:
   MaxLoadouts: 2
   manager: {fileID: 0}
   throwVelocity: 6.5
+  swapCooldown: 0.25
   dropItemInputAction: {fileID: -8197223153440005221, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}
   incrementLoadoutSelection: {fileID: -1289574976295722738, guid: 98323288612fc7b4ba4be833f71dd9ca, type: 3}
   decrementLoadoutSelection: {fileID: 0}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2124,7 +2124,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: 0.1
   far clip plane: 1000
   field of view: 60
   orthographic: 0

--- a/Assets/Scripts/Equipment/PlayerLoadout.cs
+++ b/Assets/Scripts/Equipment/PlayerLoadout.cs
@@ -46,6 +46,9 @@ namespace nickmaltbie.Treachery.Equipment
         [SerializeField]
         public float throwVelocity = 8.0f;
 
+        [SerializeField]
+        public float swapCooldown = 0.25f;
+
         public InputActionReference dropItemInputAction;
         public InputActionReference incrementLoadoutSelection;
         public InputActionReference decrementLoadoutSelection;
@@ -61,6 +64,7 @@ namespace nickmaltbie.Treachery.Equipment
         private (InputAction, Action<CallbackContext>)[] numberOptions;
 
         public IActionActor<PlayerAction> Actor { get; private set; }
+        private float lastSwapTime = Mathf.NegativeInfinity;
 
         private KeyControl GetDigitKey(int index)
         {
@@ -249,6 +253,7 @@ namespace nickmaltbie.Treachery.Equipment
                 return;
             }
 
+            lastSwapTime = Time.time;
             currentLoadout.Value = selected;
         }
 
@@ -354,6 +359,11 @@ namespace nickmaltbie.Treachery.Equipment
 
         public bool CanSwapLaodout()
         {
+            if (Time.time < lastSwapTime + swapCooldown)
+            {
+                return false;
+            }
+
             return Actor.CanPerform(PlayerAction.SwapLoadout);
         }
     }

--- a/Assets/Scripts/Equipment/PlayerLoadout.cs
+++ b/Assets/Scripts/Equipment/PlayerLoadout.cs
@@ -101,10 +101,18 @@ namespace nickmaltbie.Treachery.Equipment
         public override void OnDestroy()
         {
             base.OnDestroy();
+            if (incrementLoadoutSelection != null)
+            {
+                incrementLoadoutSelection.action.performed -= IncrementLoadout;
+            }
+
+            if (decrementLoadoutSelection != null)
+            {
+                decrementLoadoutSelection.action.performed -= DecrementLoadout;
+            }
+
             currentLoadout.OnValueChanged -= OnLoadoutSelected;
             networkLoadouts.OnListChanged -= OnLoadoutModified;
-            incrementLoadoutSelection.action.performed -= IncrementLoadout;
-            decrementLoadoutSelection.action.performed -= DecrementLoadout;
             dropItemInputAction.action.performed -= DropCurrentItem;
             loadoutScroll.action.performed -= ScrollLoadout;
             foreach ((InputAction, Action<CallbackContext>) tuple in numberOptions)
@@ -150,8 +158,8 @@ namespace nickmaltbie.Treachery.Equipment
         {
             loadouts[CurrentSelected].SetActive(true);
 
-            incrementLoadoutSelection.action.Enable();
-            decrementLoadoutSelection.action.Enable();
+            incrementLoadoutSelection?.action?.Enable();
+            decrementLoadoutSelection?.action?.Enable();
             dropItemInputAction.action.Enable();
             loadoutScroll.action.Enable();
 
@@ -181,8 +189,16 @@ namespace nickmaltbie.Treachery.Equipment
                 }
             }
 
-            incrementLoadoutSelection.action.performed += IncrementLoadout;
-            decrementLoadoutSelection.action.performed += DecrementLoadout;
+            if (incrementLoadoutSelection?.action != null)
+            {
+                incrementLoadoutSelection.action.performed += IncrementLoadout;
+            }
+            
+            if (decrementLoadoutSelection?.action != null)
+            {
+                decrementLoadoutSelection.action.performed += DecrementLoadout;
+            }
+
             dropItemInputAction.action.performed += DropCurrentItem;
             loadoutScroll.action.performed += ScrollLoadout;
             currentLoadout.OnValueChanged += OnLoadoutSelected;

--- a/Assets/Scripts/Equipment/PlayerLoadout.cs
+++ b/Assets/Scripts/Equipment/PlayerLoadout.cs
@@ -197,7 +197,7 @@ namespace nickmaltbie.Treachery.Equipment
             {
                 incrementLoadoutSelection.action.performed += IncrementLoadout;
             }
-            
+
             if (decrementLoadoutSelection?.action != null)
             {
                 decrementLoadoutSelection.action.performed += DecrementLoadout;


### PR DESCRIPTION
# Description

Refactored some basic player actions.
* Added basic cooldown to swapping items
* Changed default zoom level and disabled manual camera zoom
* Decreased number of held loadouts from 3 to 2
* Changed swapping loadout to be controlled by `tab` key instead of forward button.

